### PR TITLE
Remove freeing of data

### DIFF
--- a/TBQuadTree.podspec
+++ b/TBQuadTree.podspec
@@ -11,16 +11,4 @@ Pod::Spec.new do |s|
   	}
   	s.source_files = 'TBQuadTree/**/*.{m,h}'
 	s.requires_arc = true
-	s.documentation = { 
-		:appledoc => [
-			'--project-name',      s.name + ' ' + s.version.to_s(),
-			'--project-company',   'thoughtbot',
-			'--docset-copyright',  'thoughtbot',
-	    	'--ignore',            'TBQuadTreeTests',
-	    	'--no-keep-undocumented-objects',
-	    	'--no-keep-undocumented-members',
-	    	'--no-repeat-first-par',
-	    	'--no-warn-invalid-crossref'
-	    ]
-	}
 end

--- a/TBQuadTree/TBQuadTree.m
+++ b/TBQuadTree/TBQuadTree.m
@@ -138,9 +138,6 @@ void TBFreeQuadTreeNode(TBQuadTreeNode* node)
     if (node->southWest != NULL) TBFreeQuadTreeNode(node->southWest);
     if (node->southEast != NULL) TBFreeQuadTreeNode(node->southEast);
 
-    for (int i=0; i < node->count; i++) {
-        free(node->points[i].data);
-    }
     free(node->points);
     free(node);
 }


### PR DESCRIPTION
It seems like it was freeing data that it didn't create, nor was it realistically the owner of that data.

I was getting crashes when trying to free the TBQuadTree using the `TBFreeQuadTreeNode`. It turns out that it was freeing the data referenced in that data pointer and my understanding is that that shouldn't be the case.